### PR TITLE
Add back javascript.jsx to the languageIds

### DIFF
--- a/src/server/utils/languageModeIds.ts
+++ b/src/server/utils/languageModeIds.ts
@@ -9,6 +9,7 @@ export const typescripttsx = 'typescript.tsx'
 export const typescriptjsx = 'typescript.jsx'
 export const javascript = 'javascript'
 export const javascriptreact = 'javascriptreact'
+export const javascriptjsx = 'javascript.jsx'
 export const jsxTags = 'jsx-tags'
 
-export const languageIds = [typescript, typescriptreact, javascript, javascriptreact, typescripttsx, jsxTags]
+export const languageIds = [typescript, typescriptreact, javascript, javascriptreact, javascriptjsx, typescripttsx, jsxTags]


### PR DESCRIPTION
The change in https://github.com/neoclide/coc-tsserver/commit/c5c1630d8533136e20bfdc72d1846c4ef87a0c9e broke the autocompletion for `javascript.jsx` filetypes.

This PR adds it back while reserving the recently added `javascriptreact` filetype.