### PR TITLE
bug fix: workspace.cwd -> workspace.root in getProjectRootPath()

### DIFF
--- a/src/server/typescriptServiceClient.ts
+++ b/src/server/typescriptServiceClient.ts
@@ -815,7 +815,7 @@ export default class TypeScriptServiceClient implements ITypeScriptServiceClient
   public getProjectRootPath(uri: string): string {
     let u = Uri.parse(uri)
     if (u.scheme != 'file') return workspace.cwd
-    if (u.fsPath.startsWith(workspace.root) && workspace.root != os.homedir()) return workspace.cwd
+    if (u.fsPath.startsWith(workspace.root) && workspace.root != os.homedir()) return workspace.root
     let res = findUp.sync(['tsconfig.json', 'jsconfig.json'], { cwd: path.dirname(u.fsPath) })
     return res ? path.dirname(res) : workspace.cwd
   }


### PR DESCRIPTION
I think workspace.cwd should become workspace.root, this fixes the tsserver behaviour in my projects (where I use paths, etc in my tsconfig.json), without this the getProjectRootPath method returns the 'source file' path .

Please correct me if I am wrong, I am still new to the project (and never used visual studio) , so this took me some hours to figure out ;)