### PR TITLE
Add missing option "auto" to importModuleSpecifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,7 +226,8 @@
           "default": "non-relative",
           "enum": [
             "non-relative",
-            "relative"
+            "relative",
+            "auto"
           ]
         },
         "typescript.preferences.noSemicolons": {


### PR DESCRIPTION
Hi,

Very minor thing, but just noticed that the "auto" option was missing in importModuleSpecifier