### PR TITLE
resolve `tsserver.js` via an absolute path

### DIFF
--- a/src/server/utils/versionProvider.ts
+++ b/src/server/utils/versionProvider.ts
@@ -21,7 +21,7 @@ export class TypeScriptVersion {
   }
 
   public get tsServerPath(): string {
-    return path.join(this.path, 'tsserver.js')
+    return path.resolve(this.path, 'tsserver.js')
   }
 
   public get pathLabel(): string {


### PR DESCRIPTION
this commit changes the `tsserver.js` resolution logic to use an absolute path rather than a relative one.

previously, if a user wanted to use a `tsserver.js` that was local to a project but didn't live in
`node_modules` (which would be automatically resolved by default), the `tsserver.tsdk` needed to be hardcoded to an absolute path. this required the user to modify `coc-settings.json` each time they wished to switch projects. by resolving to an absolute path, a user can now set the value to a relative path which will resolve correctly per project.

this change facilitates simplified usage of [Yarn v2's PnP feature](https://yarnpkg.github.io/berry/features/pnp), which [can generate](https://yarnpkg.github.io/berry/advanced/pnpify/) a project-specific `tsserver.js` to enable correct IDE integration.