### PR TITLE
Dispose of status bar item when disabling tsserver

### DIFF
--- a/src/server/typescriptServiceClient.ts
+++ b/src/server/typescriptServiceClient.ts
@@ -161,6 +161,7 @@ export default class TypeScriptServiceClient implements ITypeScriptServiceClient
     this.logger.dispose()
     this._onTsServerStarted.dispose()
     this._onResendModelsRequested.dispose()
+    this.versionStatus.dispose()
   }
 
   private info(message: string, data?: any): void {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11974624/64059624-44f79800-cc14-11e9-8946-3d42f015cdee.png)

The `coc-tsserver` status bar item is not disposed of when disabling/toggling the extension in `coc.nvim`. This PR ensures the status bar item is removed so the duplication situation above does not occur.