### PR TITLE
fix rename feature

### DIFF
--- a/src/server/features/fileConfigurationManager.ts
+++ b/src/server/features/fileConfigurationManager.ts
@@ -146,6 +146,7 @@ export default class FileConfigurationManager {
       quotePreference: config.get<'single' | 'double' | 'auto'>('preferences.quoteStyle', defaultQuote),
       allowRenameOfImportPath: true,
       allowTextChangesInNewFiles: true,
+      providePrefixAndSuffixTextForRename: true
     }
   }
 }

--- a/src/server/features/fileConfigurationManager.ts
+++ b/src/server/features/fileConfigurationManager.ts
@@ -146,7 +146,7 @@ export default class FileConfigurationManager {
       quotePreference: config.get<'single' | 'double' | 'auto'>('preferences.quoteStyle', defaultQuote),
       allowRenameOfImportPath: true,
       allowTextChangesInNewFiles: true,
-      providePrefixAndSuffixTextForRename: true
+      providePrefixAndSuffixTextForRename: true,
     }
   }
 }

--- a/src/server/features/rename.ts
+++ b/src/server/features/rename.ts
@@ -98,7 +98,7 @@ export default class TypeScriptRenameProvider implements RenameProvider {
         for (const textSpan of spanGroup.locs) {
           changes[uri].push({
             range: typeConverters.Range.fromTextSpan(textSpan),
-            newText: newName
+            newText:  (textSpan.prefixText || '') + newName + (textSpan.suffixText || '')
           })
         }
       }


### PR DESCRIPTION
Set 'providePrefixAndSuffixTextForRename' to true, as default in VSCode.
append "prefixText"  and "suffixText" if returned by tsserver 
Closes https://github.com/neoclide/coc-tsserver/issues/85