### PR TITLE
Deprecate TSLint

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -140,8 +140,9 @@ or `javascript` in your `coc-settings.json`.
 
 ## Related extensions
 
+- [coc-eslint](https://github.com/neoclide/coc-eslint): enable [eslint](https://github.com/eslint/eslint) plugin for tsserver to lint typsecript and javascript files.
 - [coc-tslint-plugin](https://github.com/neoclide/coc-tslint-plugin): enable [tslint](https://github.com/palantir/tslint)
-  plugin for tsserver.
+  plugin for tsserver ([deprecated](https://github.com/palantir/tslint/issues/4534)).
 - [coc-vetur](https://github.com/neoclide/coc-vetur): [vue](https://github.com/vuejs/vue) extension.
 - [coc-angular](https://github.com/iamcco/coc-angular): [angular](https://github.com/angular/angular) extension.
 

--- a/Readme.md
+++ b/Readme.md
@@ -140,7 +140,7 @@ or `javascript` in your `coc-settings.json`.
 
 ## Related extensions
 
-- [coc-eslint](https://github.com/neoclide/coc-eslint): enable [eslint](https://github.com/eslint/eslint) plugin for tsserver to lint typsecript and javascript files.
+- [coc-eslint](https://github.com/neoclide/coc-eslint): enable [eslint](https://github.com/eslint/eslint) plugin for tsserver to lint TypeScript and JavaScript files.
 - [coc-tslint-plugin](https://github.com/neoclide/coc-tslint-plugin): enable [tslint](https://github.com/palantir/tslint)
   plugin for tsserver ([deprecated](https://github.com/palantir/tslint/issues/4534)).
 - [coc-vetur](https://github.com/neoclide/coc-vetur): [vue](https://github.com/vuejs/vue) extension.


### PR DESCRIPTION
TSLint has been [deprecated](https://github.com/palantir/tslint/issues/4534).  Should put `eslint` first to direct users there.