### PR TITLE
Add setting to configure the max memory for tsserver

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -79,6 +79,7 @@ Checkout [using the configuration file](https://github.com/neoclide/coc.nvim/wik
 - `tsserver.typingsCacheLocation`:Folder path for cache typings, default: `""`
 - `tsserver.formatOnType`:Run format on type special characters., default: `true`
 - `tsserver.enableJavascript`:Use tsserver for javascript files, default: `true`
+- `tsserver.maxTsServerMemory`:Set the maximum amount of memory to allocate to the TypeScript server process
 - `tsserver.tsdk`:Directory contains tsserver.js,, default: `""`
 - `tsserver.npm`:Executable path of npm for download typings, default: `""`
 - `tsserver.log`:Log level of tsserver, default: `"off"`

--- a/package.json
+++ b/package.json
@@ -134,6 +134,11 @@
           "default": false,
           "description": "Always use tsserver module from tsserver.tsdk or tsserver extension."
         },
+        "tsserver.maxTsServerMemory": {
+          "type": "number",
+          "default": 0,
+          "description": "Set the maximum amount of memory to allocate to the TypeScript server process"
+        },
         "tsserver.tsdk": {
           "type": "string",
           "default": "",

--- a/src/server/typescriptServiceClient.ts
+++ b/src/server/typescriptServiceClient.ts
@@ -278,8 +278,12 @@ export default class TypeScriptServiceClient implements ITypeScriptServiceClient
     this.lastError = null
     const tsServerForkArgs = await this.getTsServerArgs()
     const debugPort = this._configuration.debugPort
+    const maxTsServerMemory = this._configuration.maxTsServerMemory
     const options = {
-      execArgv: debugPort ? [`--inspect=${debugPort}`] : [], // [`--debug-brk=5859`]
+      execArgv: [
+          ...(debugPort ? [`--inspect=${debugPort}`] : []), // [`--debug-brk=5859`]
+          ...(maxTsServerMemory ? [`--max-old-space-size=${maxTsServerMemory}`] : []),
+      ],
       cwd: workspace.root
     }
     this.servicePromise = this.startProcess(currentVersion, tsServerForkArgs, options, resendModels)

--- a/src/server/utils/configuration.ts
+++ b/src/server/utils/configuration.ts
@@ -88,6 +88,10 @@ export class TypeScriptServiceConfiguration {
     return this._configuration.get<boolean>('formatOnType', false)
   }
 
+  public get maxTsServerMemory(): number {
+    return this._configuration.get<number>('maxTsServerMemory', 0)
+  }
+
   public get debugPort(): number | null {
     return this._configuration.get<number>('debugPort', parseInt(process.env['TSS_DEBUG'], 10))
   }


### PR DESCRIPTION
When working with a huge project tsserver runs out of memory, so we need a way to configure memory limits for tsserver via coc-tsserver configuration. This is a direct port of VSCode change: https://github.com/microsoft/vscode/pull/82630/files/f22cde58663ba28d10ba43861a736b3c92f0a12b