### PR TITLE
Support the new path of Yarn v2 pnpify SDK

### DIFF
--- a/src/server/utils/versionProvider.ts
+++ b/src/server/utils/versionProvider.ts
@@ -84,7 +84,7 @@ export class TypeScriptVersion {
   }
 }
 
-const MODULE_FOLDERS = ['node_modules/typescript/lib', '.vscode/pnpify/typescript/lib']
+const MODULE_FOLDERS = ['node_modules/typescript/lib', '.vscode/pnpify/typescript/lib', '.yarn/sdks/typescript/lib']
 
 export class TypeScriptVersionProvider {
 


### PR DESCRIPTION
Pnpify SDKs are not located in `.vscode/pnpify` anymore. It's in `.yarn/sdks` instead. Adding it to `MODULE_FOLDERS`.

Without this patch, coc-tsserver works only when vim's CWD is exactly same with `.vim` directories location. For example, if you execute vim in the child directory, coc-tsserver does not work, which is not desirable.

###### References
- https://github.com/yarnpkg/berry/pull/1446: `.vscode/pnpify` &rarr; `.yarn/pnpify`
- https://github.com/yarnpkg/berry/pull/1481: `.yarn/pnpify` &rarr; `.yarn/sdks`
- https://github.com/neoclide/coc-tsserver/commit/52f625c453d36896252f2ab1818ff8c950222c7a#diff-5638766bbef81a3af0ffe200b24627e9
- https://github.com/neoclide/coc-tsserver/issues/166