### PR TITLE
Fix peer-dependency install issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "build": "webpack",
-    "prepare": "npx npm-run-all clean build"
+    "prepare": "npm run clean && npm run build"
   },
   "activationEvents": [
     "onLanguage:javascript",
@@ -612,8 +612,8 @@
   "author": "chemzqm@gmail.com",
   "license": "MIT",
   "devDependencies": {
-    "@chemzqm/tsconfig": "^0.0.3",
-    "@chemzqm/tslint-config": "^1.0.18",
+    "@sourcegraph/eslint-config": "^0.20.12",
+    "@sourcegraph/tsconfig": "^4.0.1",
     "@types/fast-diff": "^1.2.0",
     "@types/node": "^14.0.23",
     "coc.nvim": "^0.0.77",
@@ -623,9 +623,9 @@
     "ts-loader": "^8.0.1",
     "tslint": "^6.1.2",
     "vscode-languageserver-protocol": "^3.15.3",
+    "vscode-languageserver-textdocument": "^1.0.1",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12",
-    "vscode-languageserver-textdocument": "^1.0.1",
     "which": "^2.0.2"
   },
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./node_modules/@chemzqm/tsconfig/tsconfig.json",
+  "extends": "./node_modules/@sourcegraph/tsconfig/tsconfig.json",
   "compilerOptions": {
     "declaration": false,
     "outDir": "lib",

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./node_modules/@chemzqm/tslint-config/tslint.json",
+  "extends": "./node_modules/@sourcegraph/tslint-config/tslint.json",
   "rules": {
     "no-floating-promises": false,
     "no-invalid-template-strings": false


### PR DESCRIPTION
The tsconfig and tslint-config packages seem unmaintained and have
outdated peer dependencies, which seem to break on new versions of
Node.js (?). This commit resolves the problem by introducing their
`@sourcegraph/ts(lint-)config` counterparts, which seems to resolve the
problem.

Remaining problems:

- npm-run-all seems broken, locally I've replaced with the barebones
  `npm run clean && npm run build`, which seems to work.
- the webpack build during `npm run build` now seems to fail with a
  bunch of TypeScript errors -- this is *not* resolved.

See-also: #214 