### PR TITLE
Get rid of npm-run-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "build": "webpack",
-    "prepare": "npx npm-run-all clean build"
+    "prepare": "yarn clean && yarn build"
   },
   "activationEvents": [
     "onLanguage:javascript",


### PR DESCRIPTION
`npm-run-all` do not work properly with npm 7.0.14 like below. And also it haven't updated for 2 years. Since this project don
t really need npm-run-all anyway, I hereby make a PR getting rid of it.

![image](https://user-images.githubusercontent.com/4435445/101096107-66f37d80-3602-11eb-88ad-6eb57feefadb.png)
