### PR TITLE
README - Add info about typescript issue 37777

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -73,7 +73,7 @@ Almost the same as VSCode.
   - `tsserver.organizeImports`
   - `tsserver.watchBuild`
 - Code completion support.
-- Go to definition.
+- Go to definition (does not work in typescript https://github.com/microsoft/TypeScript/issues/37777)
 - Code validation.
 - Document highlight.
 - Document symbols of current buffer.

--- a/Readme.md
+++ b/Readme.md
@@ -73,7 +73,7 @@ Almost the same as VSCode.
   - `tsserver.organizeImports`
   - `tsserver.watchBuild`
 - Code completion support.
-- Go to definition (use ctags to navigate typescript node_modules https://github.com/microsoft/TypeScript/issues/37777)
+- Go to definition (use ctags to navigate typescript node_modules [microsoft/TypeScript#37777](https://github.com/microsoft/TypeScript/issues/37777))
 - Code validation.
 - Document highlight.
 - Document symbols of current buffer.

--- a/Readme.md
+++ b/Readme.md
@@ -73,7 +73,7 @@ Almost the same as VSCode.
   - `tsserver.organizeImports`
   - `tsserver.watchBuild`
 - Code completion support.
-- Go to definition (does not work in typescript https://github.com/microsoft/TypeScript/issues/37777)
+- Go to definition (use ctags to navigate typescript node_modules https://github.com/microsoft/TypeScript/issues/37777)
 - Code validation.
 - Document highlight.
 - Document symbols of current buffer.

--- a/Readme.md
+++ b/Readme.md
@@ -73,7 +73,7 @@ Almost the same as VSCode.
   - `tsserver.organizeImports`
   - `tsserver.watchBuild`
 - Code completion support.
-- Go to definition (use ctags to navigate typescript node_modules [microsoft/TypeScript#37777](https://github.com/microsoft/TypeScript/issues/37777))
+- Go to definition (more info in [microsoft/TypeScript#37777](https://github.com/microsoft/TypeScript/issues/37777))
 - Code validation.
 - Document highlight.
 - Document symbols of current buffer.


### PR DESCRIPTION
The README is not clear on this.

Go to definition does not work in typescript node_modules
ctags https://github.com/jb55/typescript-ctags is not a great alternative as it does not work well with ES6

Including the link to https://github.com/microsoft/TypeScript/issues/37777 has two benefits:
- will drive traffic to that issue and hopefully microsoft will solve it
- will help user find a workaround

tested on TypeScript 4.0.3