### PR TITLE
fix: save tsEntry.data for resolveCompletionItem

### DIFF
--- a/src/server/features/completionItemProvider.ts
+++ b/src/server/features/completionItemProvider.ts
@@ -222,7 +222,7 @@ export default class TypeScriptCompletionItemProvider implements CompletionItemP
   ): Promise<CompletionItem> {
     if (item == null) return undefined
 
-    let { uri, position, source, name } = item.data
+    let { uri, position, source, name, data } = item.data
     const filepath = this.client.toPath(uri)
     if (!filepath) return undefined
     let document = workspace.getDocument(uri)
@@ -232,7 +232,7 @@ export default class TypeScriptCompletionItemProvider implements CompletionItemP
         filepath,
         position
       ),
-      entryNames: [source ? { name, source } : name]
+      entryNames: [source ? { name, source, data } : name]
     }
 
     let response: ServerResponse.Response<Proto.CompletionDetailsResponse>

--- a/src/server/utils/completionItem.ts
+++ b/src/server/utils/completionItem.ts
@@ -106,6 +106,7 @@ export function convertCompletionEntry(
       uri,
       position,
       name: tsEntry.name,
+      data: tsEntry.data,
       source: tsEntry.source || ''
     }
   }


### PR DESCRIPTION
close #293

cc @chemzqm, tsserver returns `tsEntry.data` can be used in `resolveCompletionItem`, we can save it in `completionItem.data` to use.