### PR TITLE
docs: update yarn configuration

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -48,14 +48,15 @@ In your vim/neovim, run command:
 
 For yarn2 ( >= v2.0.0-rc.36) user want to use local typescript module:
 
-- Run command `yarn dlx @yarnpkg/pnpify --sdk vim`, which will generate
+- Run command `yarn dlx @yarnpkg/sdks vim`, which will generate
   `.vim/coc-settings.json`, with content:
 
   ```json
   {
-    "tsserver.tsdk": ".yarn/sdks/typescript/lib",
     "eslint.packageManager": "yarn",
-    "eslint.nodePath": ".yarn/sdks"
+    "eslint.nodePath": ".yarn/sdks",
+    "workspace.workspaceFolderCheckCwd": false,
+    "tsserver.tsdk": ".yarn/sdks/typescript/lib"
   }
   ```
 


### PR DESCRIPTION
This pull request updates the command needs to configure coc-tsserver using yarn 2+

I've tried following the documentation to use coc-tsserver with yarn 3.1.0 by running

```sh
yarn dlx @yarnpkg/pnpify --sdk vim
```

But I've got the following response on the terminal

```sh
$ yarn dlx @yarnpkg/pnpify --sdk vim
➤ YN0000: ┌ Resolution step
➤ YN0000: └ Completed in 7s 504ms
➤ YN0000: ┌ Fetch step
➤ YN0013: │ tunnel@npm:0.0.6 can't be found in the cache and will be fetched fr
➤ YN0013: │ typanion@npm:3.3.2 can't be found in the cache and will be fetched 
➤ YN0013: │ which@npm:2.0.2 can't be found in the cache and will be fetched fro
➤ YN0013: │ wrappy@npm:1.0.2 can't be found in the cache and will be fetched fr
➤ YN0013: │ yallist@npm:4.0.0 can't be found in the cache and will be fetched f
➤ YN0000: └ Completed in 2s 411ms
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed in 0s 229ms
➤ YN0000: Done in 10s 201ms

Usage Error: The 'pnpify --sdk ...' command has been moved to the '@yarnpkg/sdks' package - use 'yarn dlx @yarnpkg/sdks ...' instead
```

It turns out that the command has already moved as docummented [here](https://yarnpkg.com/sdks/cli/default), so `@yarnpkg/pnpify` no longer include sdk configuration. Hence, to configure coc-tsserver using yarn 2+ we could run

```sh
yarn dlx @yarnpkg/sdks vim
```

EDIT:

You can read the documentation here https://yarnpkg.com/getting-started/editor-sdks