### PR TITLE
refactor: Disables type acquisition by default

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -126,7 +126,7 @@ for guide of coc.nvim's configuration.
 - `tsserver.implicitProjectConfig.experimentalDecorators`:Enable
   experimentalDecorators for implicit project, default: `false`
 - `tsserver.disableAutomaticTypeAcquisition`:Disable download of typings,
-  default: `false`
+  default: `true`
 - `tsserver.useBatchedBufferSync`: use batched buffer synchronize support.
 - `typescript.updateImportsOnFileMove.enable`:Enable update imports on file
   move., default: `true`

--- a/Readme.md
+++ b/Readme.md
@@ -48,14 +48,15 @@ In your vim/neovim, run command:
 
 For yarn2 ( >= v2.0.0-rc.36) user want to use local typescript module:
 
-- Run command `yarn dlx @yarnpkg/pnpify --sdk vim`, which will generate
+- Run command `yarn dlx @yarnpkg/sdks vim`, which will generate
   `.vim/coc-settings.json`, with content:
 
   ```json
   {
-    "tsserver.tsdk": ".yarn/sdks/typescript/lib",
     "eslint.packageManager": "yarn",
-    "eslint.nodePath": ".yarn/sdks"
+    "eslint.nodePath": ".yarn/sdks",
+    "workspace.workspaceFolderCheckCwd": false,
+    "tsserver.tsdk": ".yarn/sdks/typescript/lib"
   }
   ```
 

--- a/package.json
+++ b/package.json
@@ -252,7 +252,7 @@
         },
         "tsserver.disableAutomaticTypeAcquisition": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Disable download of typings"
         },
         "tsserver.useBatchedBufferSync": {

--- a/src/server/utils/configuration.ts
+++ b/src/server/utils/configuration.ts
@@ -86,7 +86,7 @@ export class TypeScriptServiceConfiguration {
   }
 
   public get disableAutomaticTypeAcquisition(): boolean {
-    return this._configuration.get<boolean>('disableAutomaticTypeAcquisition', false)
+    return this._configuration.get<boolean>('disableAutomaticTypeAcquisition', true)
   }
 
   public get formatOnType(): boolean {


### PR DESCRIPTION
Closes #316

Automatic type acquisition is currently horribly flawed in that it does not check that it installs a correct or matching version of the types for the module in use. If the user has no guarantee that the types package installed at least is _supposed_ to match the version of the module they're using, this can be problematic if not dangerous.

For example, as mentioned in #316, I'm running Node v14, yet given types for Node built-ins that only exist v15+. While this creates a poor editor experience, as you cannot actually trust that you are returned correct warnings/errors, this gets dangerous in crypto and validation areas. If you're running v1 of a library while @types has a v2, **you will not get the definitions or descriptions to match what version you're using**. Depending on the API changes, this can be very dangerous.

While I certainly see value in the option, I think that until it's improved it should be disabled by default. I could be in the minority in thinking as much, but wanted to put this together to at least get thoughts.