### PR TITLE
correct README importModuleSpecifier configuration examples

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -150,7 +150,7 @@ for guide of coc.nvim's configuration.
 - `typescript.referencesCodeLens.enable`:Enable codeLens for references,
   default: `true`
 - `typescript.referencesCodeLens.showOnAllFunctions`: Enable/disable references CodeLens on all functions in typescript files. Default: `false`
-- `typescript.preferences.importModuleSpecifier` default: `"auto"`
+- `typescript.preferences.importModuleSpecifier` default: `"shortest"`
 - `typescript.preferences.importModuleSpecifierEnding` default: `"auto"`
 - `typescript.preferences.quoteStyle` default: `"single"`
 - `typescript.preferences.includePackageJsonAutoImports`: Enable/disable
@@ -215,7 +215,7 @@ for guide of coc.nvim's configuration.
 - `javascript.implementationsCodeLens.enable` default: `true`
 - `javascript.referencesCodeLens.enable` default: `true`
 - `javascript.referencesCodeLens.showOnAllFunctions`: Enable/disable references CodeLens on all functions in JavaScript files default: `false`
-- `javascript.preferences.importModuleSpecifier` default: `"auto"`
+- `javascript.preferences.importModuleSpecifier` default: `"shortest"`
 - `javascript.preferences.importModuleSpecifierEnding` default: `"auto"`
 - `javascript.preferences.quoteStyle` default: `"single"`
 - `javascript.validate.enable`: Enable/disable JavaScript validation., default:


### PR DESCRIPTION
The default for these two are actually `shortest`.

[typescript](https://github.com/neoclide/coc-tsserver/blob/master/package.json#L304)

[javascript](https://github.com/neoclide/coc-tsserver/blob/master/package.json#L565)