### PR TITLE
toResource should return zipfile:// urls when using go to definition with yarn PnP

### DIFF
--- a/src/server/typescriptServiceClient.ts
+++ b/src/server/typescriptServiceClient.ts
@@ -431,6 +431,9 @@ export default class TypeScriptServiceClient implements ITypeScriptServiceClient
   }
 
   public toResource(filepath: string): string {
+    if (filepath.includes('zipfile:')) {
+      return filepath.replace(/.*zipfile:/, 'zipfile://');
+    }
     if (this._apiVersion.gte(API.v213)) {
       if (filepath.startsWith(this.inMemoryResourcePrefix + 'untitled:')) {
         let resource = Uri.parse(filepath)


### PR DESCRIPTION
with the neovim change to expect zipfile:// urls instead of zipfile: urls, the current toResource implementation does not work with going to definitions inside of zipfiles.

As far as I can tell, attempting to change the tsserver sdk in https://github.com/cometkim/berry/blob/master/.yarn/sdks/typescript/lib/tsserver.js#L80 will not work, as the use of `Uri` compresses any form of `zipfile:///` into `zipfile:/`, requiring a bypass of the current logic.