### PR TITLE
apply initializing text in VersionStatus constructor

### DIFF
--- a/src/server/utils/versionStatus.ts
+++ b/src/server/utils/versionStatus.ts
@@ -14,6 +14,8 @@ export default class VersionStatus {
     this._versionBarEntry = window.createStatusBarItem(99)
     this._onChangeEditorSub = events.on('BufEnter', this.onBufEnter, this)
     this._versionBarEntry.show()
+    this._versionBarEntry.text = 'Initializing tsserver'
+    this._versionBarEntry.isProgress = true
   }
 
   public dispose(): void {


### PR DESCRIPTION
Hi!
Initializing tsserver text is not showing after vim launching.
```
❯ vim --version
VIM - Vi IMproved 9.0 (2022 Jun 28, compiled Aug 06 2022 10:35:28)
macOS version - x86_64
```
I'm using `lightline` to display a status of `tsserver`:
```vim
let g:lightline = {
  \ 'active': {
  \   'left': [ [ 'mode', 'paste' ],
  \             [ 'cocstatus', 'readonly', 'filename', 'modified' ] ]
  \ },
  \ 'component_function': {
  \   'cocstatus': 'coc#status'
  \ },
  \ }
```
I've test it and `loading` setter changing immediately from `true` on `false`.
```javascript
  public set loading(isLoading: boolean) {
    if (isLoading) {
      this._versionBarEntry.text = `Initializing tsserver ${this._versionString}`
    } else {
      this._versionBarEntry.text = `TSC ${this._versionString}`
    }
    this._versionBarEntry.isProgress = isLoading
  }
```
The only way to see a loading indicator is manual `:CocRestart`