### PR TITLE
goToSourceDefinition: skip preview if only one definition

### DIFF
--- a/src/server/commands.ts
+++ b/src/server/commands.ts
@@ -358,12 +358,11 @@ export class SourceDefinitionCommand implements Command {
           typeConverters.Location.fromTextSpan(client.serviceClient.toResource(reference.file), reference))
 
         if (locations.length) {
-          commands.executeCommand('editor.action.showReferences', document.uri, position, locations)
-          // if (locations.length === 1) {
-          //   commands.executeCommand('vscode.open', locations[0].uri)
-          // } else {
-          //   commands.executeCommand('editor.action.showReferences', document.uri, position, locations)
-          // }
+          if (locations.length === 1) {
+            commands.executeCommand('vscode.open', locations[0].uri)
+          } else {
+            commands.executeCommand('editor.action.showReferences', document.uri, position, locations)
+          }
           return
         }
       }


### PR DESCRIPTION
Hi - opening this as a half PR/half question, as I haven't figured out yet how to test this myself.

Is it possible to change the `goToSourceDefinition` command to go directly to the definition if only one is found, rather than showing a list (of one) to choose from? There's some commented out code in the file which suggests there is, but I'm not sure why it was commented out.

This PR comments it back in - however as I've said I haven't figured out how to test it. If you could tell me what I need to put in my `init.vim` to point to my branch then I will test it and report back. Currently I have `Plug 'neoclide/coc.nvim', {'branch': 'release'}` in my `init.vim` but nothing as far as I can see that points explicitly at `coc-tsserver`.

Thanks!