### PR TITLE
Fix(refactor): File rename does not update import paths

### DIFF
--- a/src/server/features/updatePathOnRename.ts
+++ b/src/server/features/updatePathOnRename.ts
@@ -41,7 +41,7 @@ interface RenameAction {
 
 export default class UpdateImportsOnFileRenameHandler {
   private disposables: Disposable[] = []
-  private readonly _delayer = new Delayer(50);
+  private readonly _delayer = new Delayer(1000);
   private readonly _pendingRenames = new Set<RenameAction>();
 
   public constructor(


### PR DESCRIPTION
Closes #446 by increasing the delay value to `1000`. Hopefully this is big enough to work on slower machines and short enough not to get noticed by end-users.