### PR TITLE
feat: pass through `typescript.unstable` to tsserver

### DIFF
--- a/src/server/features/fileConfigurationManager.ts
+++ b/src/server/features/fileConfigurationManager.ts
@@ -178,6 +178,7 @@ export default class FileConfigurationManager {
     const preferencesConfig = workspace.getConfiguration(`${language}.preferences`, doc)
 
     const preferences: Proto.UserPreferences = {
+      ...config.get('unstable'),
       quotePreference: this.getQuoteStyle(preferencesConfig),
       importModuleSpecifierPreference: getImportModuleSpecifier(preferencesConfig) as any,
       importModuleSpecifierEnding: getImportModuleSpecifierEndingPreference(preferencesConfig),


### PR DESCRIPTION
Closes https://github.com/neoclide/coc-tsserver/issues/453