### PR TITLE
Add configuration for ignoring the suggestion 'This may be converted to an async function. (tsserver 80006)'

### DIFF
--- a/package.json
+++ b/package.json
@@ -399,6 +399,12 @@
           "scope": "resource",
           "description": "Show deprecated variable hint."
         },
+        "typescript.showConvertToAsync": {
+          "type": "boolean",
+          "default": true,
+          "scope": "resource",
+          "description": "Enable/Disable TS80006 suggestion (convert to async) in diagnostics"
+        },
         "typescript.updateImportsOnFileMove.enabled": {
           "type": "string",
           "enum": [

--- a/src/server/languageProvider.ts
+++ b/src/server/languageProvider.ts
@@ -279,6 +279,7 @@ export default class LanguageProvider {
     const config = workspace.getConfiguration(this.id, resource)
     const reportUnnecessary = config.get<boolean>('showUnused', true)
     const reportDeprecated = config.get<boolean>('showDeprecated', true)
+    const reportConvertToAsyncFunction = config.get<boolean>('showConvertToAsync', true)
     this.client.diagnosticsManager.updateDiagnostics(resource, this._diagnosticLanguage, diagnosticsKind, diagnostics.filter(diag => {
       if (!reportUnnecessary) {
         if (diag.reportUnnecessary && diag.severity === DiagnosticSeverity.Information) {
@@ -288,6 +289,11 @@ export default class LanguageProvider {
       if (!reportDeprecated) {
         if (diag.reportDeprecated && diag.severity === DiagnosticSeverity.Hint) {
           return false
+        }
+      }
+      if (!reportConvertToAsyncFunction) {
+        if (diag.code === 80006) {
+          return false;
         }
       }
       return true


### PR DESCRIPTION
The suggestion _80006_ ("_This may be converted to an async function._") is a matter of coding style, and not everyone wants to be alerted about it. Personally, in some situations, I prefer the _promise.then_ style over using _await_.

I couldn’t find any existing option to skip this suggestion, and it doesn’t appear to be exposed at the _tsserver_ level. As a _coc-tsserver_ user, I have therefore chosen to address the issue by modifying _coc-tsserver_ itself.