### PR TITLE
feat: add typescript.tsserverRequest command and global plugin support

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -86,6 +86,30 @@ export default class TsserverService implements IServiceProvider {
         this.restart()
       }
     })
+    // Bridge command for plugins that need to communicate with tsserver (e.g. Volar)
+    registCommand({
+      id: 'typescript.tsserverRequest',
+      execute: async (command: string, args: any, options?: any): Promise<{ body: any } | undefined> => {
+        const host = await this.getClientHost()
+        const client = (host as any).serviceClient as any
+        const serverState = client.serverState
+        if (!serverState || serverState.type !== 1) {
+          return undefined
+        }
+        const results = serverState.server.executeImpl(command, args, {
+          isAsync: options?.isAsync ?? false,
+          token: undefined,
+          expectsResult: true,
+          lowPriority: options?.lowPriority ?? false,
+        })
+        if (!results || !results[0]) return undefined
+        const response = await results[0]
+        if (!response || response.type === 'noContent' || response.type === 'cancelled') {
+          return undefined
+        }
+        return { body: (response as any).body }
+      }
+    })
   }
 
   public get config(): WorkspaceConfiguration {

--- a/src/server/typescriptServiceClient.ts
+++ b/src/server/typescriptServiceClient.ts
@@ -457,12 +457,30 @@ export default class TypeScriptServiceClient extends Disposable implements IType
     const watchOptions = this.apiVersion.gte(API.v380)
       ? this.configuration.watchOptions
       : undefined
+    // Resolve node_modules path for each contributed plugin
+    const pluginPaths: string[] = []
+    const globalPlugins: string[] = []
+    for (const plugin of this.pluginManager.plugins) {
+      globalPlugins.push(plugin.name)
+      try {
+        const pkgPath = require.resolve(plugin.name + '/package.json')
+        const nmIdx = pkgPath.lastIndexOf(path.sep + 'node_modules' + path.sep)
+        if (nmIdx !== -1) {
+          const dir = pkgPath.slice(0, nmIdx)
+          if (!pluginPaths.includes(dir)) {
+            pluginPaths.push(dir)
+          }
+        }
+      } catch {}
+    }
     const configureOptions: Proto.ConfigureRequestArguments = {
       hostInfo: 'coc-nvim',
       preferences: {
         providePrefixAndSuffixTextForRename: true,
         allowRenameOfImportPath: true,
-        includePackageJsonAutoImports: this._configuration.includePackageJsonAutoImports
+        includePackageJsonAutoImports: this._configuration.includePackageJsonAutoImports,
+        pluginPaths,
+        globalPlugins,
       },
       watchOptions
     }


### PR DESCRIPTION
### Changes

1. **typescriptServiceClient.ts** — send `globalPlugins` and `pluginPaths` in the `configure` request. This ensures that TypeScript plugins contributed via `typescriptServerPlugins` are automatically discovered and loaded by tsserver.

2. **server/index.ts** — register a new `typescript.tsserverRequest` command. This allows other plugins (like Volar) to forward arbitrary tsserver commands through coc-tsserver's managed tsserver process.

### Why

Volar v3 requires a `tsserver/request` ↔ `tsserver/response` bridge between the Vue language server and TypeScript. The VS Code extension uses the built-in `typescript.tsserverRequest` command provided by `vscode.typescript-language-features`. coc.nvim needs the equivalent command to support this pattern.

### Testing

Tested with `@vue/language-server` v3.3.4:
- Basic LSP features (completion, hover, diagnostics, formatting) work
- TypeScript-backed Vue features (component names, props, directives) work via the bridge
- All `typescriptServerPlugins` contributions are loaded globally without requiring a `tsconfig.json` entry